### PR TITLE
Fixed python3 import compability issues.

### DIFF
--- a/pygett/__init__.py
+++ b/pygett/__init__.py
@@ -1,1 +1,1 @@
-from base import Gett
+from pygett.base import Gett

--- a/pygett/base.py
+++ b/pygett/base.py
@@ -1,10 +1,10 @@
 import re
 import time
 
-from user import GettUser
-from request import GettRequest
-from shares import GettShare
-from files import GettFile
+from pygett.user import GettUser
+from pygett.request import GettRequest
+from pygett.shares import GettShare
+from pygett.files import GettFile
 
 
 class Gett(object):

--- a/pygett/files.py
+++ b/pygett/files.py
@@ -1,4 +1,4 @@
-from request import GettRequest
+from pygett.request import GettRequest
 
 
 class GettFile(object):

--- a/pygett/request.py
+++ b/pygett/request.py
@@ -1,6 +1,6 @@
 import requests
 import simplejson as json
-from exceptions import GettError
+from pygett.exceptions import GettError
 
 
 class GettResponse(object):

--- a/pygett/shares.py
+++ b/pygett/shares.py
@@ -1,5 +1,5 @@
-from request import GettRequest
-from files import GettFile
+from pygett.request import GettRequest
+from pygett.files import GettFile
 
 
 class GettShare(object):

--- a/pygett/user.py
+++ b/pygett/user.py
@@ -1,5 +1,5 @@
 from time import time
-from request import GettRequest
+from pygett.request import GettRequest
 
 
 class GettUser(object):


### PR DESCRIPTION
Python3 requires _explicit imports_ which explicitly specify location of the imported modules.
